### PR TITLE
pin jsonschema to 4.19.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 openapi-spec-validator==0.6.0
 prance==23.6.21.0
 pyyaml==6.0.1
+jsonschema==4.19.0


### PR DESCRIPTION
## Describe your changes

prance relies on jsonschema but it isn't pinned

for some reason with jsonschema 4.9.1 installed, the [import openapi_spec_validator in prance](https://github.com/RonnyPfannschmidt/prance/blob/2b91d0776630512843ca7d2975f963080a5c3bb6/prance/util/__init__.py#L43) raises the following exception:

```
cannot import name '_legacy_validators' from 'jsonschema'
```

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have resolved any merge conflicts
- [x] I have run tests locally and they pass
- [x] I have linted and auto-formatted the code
- [x] If there is new or changed functionality, I have added/updated the tests
- [x] If there is new or changed functionality, I have added/updated the documentation
